### PR TITLE
Fix npm build command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "coffeetape test/*.coffee | faucet",
     "test-saucelabs": "zuul -- test/*.coffee",
-    "build": "npm run build-lib & npm run build-dist",
+    "build": "npm run build-lib ; npm run build-dist",
     "watch": "npm run watch-lib & npm run watch-dist",
     "build-lib": "coffee -o lib --compile --bare --map src/",
     "watch-lib": "coffee -o lib --compile --bare --map --watch src/*.coffee",


### PR DESCRIPTION
& tells Linux environment to run previous command in background. Such behavior led to issue that `npm run build-dist` (that relies on result of `npm run build-lib`) produced empty JS file.