### PR TITLE
Fix library build for npm v7 and above on Windows platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zxcvbn",
-  "version": "4.4.3",
+  "version": "4.4.2+sana.2",
   "description": "realistic password strength estimation",
   "author": "Dan Wheeler",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "test": "coffeetape test/*.coffee | faucet",
     "test-saucelabs": "zuul -- test/*.coffee",
-    "build": "npm run build-lib ; npm run build-dist",
-    "watch": "npm run watch-lib & npm run watch-dist",
+    "build": "npm run build-lib && npm run build-dist",
+    "watch": "npm run watch-lib && npm run watch-dist",
     "build-lib": "coffee -o lib --compile --bare --map src/",
     "watch-lib": "coffee -o lib --compile --bare --map --watch src/*.coffee",
     "build-dist": "browserify --debug  --standalone zxcvbn -t uglifyify lib/main.js | exorcist --base . dist/zxcvbn.js.map > dist/zxcvbn.js",


### PR DESCRIPTION
Replaces ';' and '&' operands in 'build' and 'watch' scripts with '&&' which runs next operation if previous operation successfully completed. This fixes failure of direct library installation from github repository on Windows platform using npm v7 and above.

Tested on Windows 10/11, Alpine Linux 3.16.2, Ubuntu 22.04.1 and Mac OS 12.5 using Node.js v14.17.3 (npm v6/v7) and v16.17.0 (npm v8).